### PR TITLE
Noise spec polish: close on ErrMaxNonce + Fingerprint() (stacked on #12)

### DIFF
--- a/pkg/transport/bolt8/bolt8_test.go
+++ b/pkg/transport/bolt8/bolt8_test.go
@@ -51,7 +51,7 @@ func TestActVectorsInitiator(t *testing.T) {
 	expectedAct3 := fromHex(t, "00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba")
 
 	rw := &capturingRW{toRead: stubAct2}
-	ck, err := runInitiator(rw, lsPriv, rsPub, ePriv)
+	ck, _, err := runInitiator(rw, lsPriv, rsPub, ePriv)
 	if err != nil {
 		t.Fatalf("runInitiator: %v", err)
 	}
@@ -252,5 +252,56 @@ func TestRekey(t *testing.T) {
 		if !bytes.Equal(got, payload) {
 			t.Fatalf("msg %d: got %q want %q", i, got, payload)
 		}
+	}
+}
+
+// TestFingerprintMatches confirms both peers derive the same handshake
+// hash, which is what makes the value useful for channel binding.
+func TestFingerprintMatches(t *testing.T) {
+	respPriv, _ := secp256k1.GeneratePrivateKey()
+	initPriv, _ := secp256k1.GeneratePrivateKey()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	serverFP := make(chan [32]byte, 1)
+	go func() {
+		raw, err := l.Accept()
+		if err != nil {
+			return
+		}
+		s := Server(raw, respPriv)
+		// Trigger handshake by reading.
+		_ = s.SetReadDeadline(time.Now().Add(2 * time.Second))
+		one := make([]byte, 1)
+		_, _ = s.Read(one)
+		serverFP <- s.Fingerprint()
+		_ = s.Close()
+	}()
+
+	addr := l.Addr().(*net.TCPAddr)
+	raw, err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(addr.Port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := Client(raw, initPriv, respPriv.PubKey())
+	defer c.Close()
+	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := c.Write([]byte("x")); err != nil {
+		t.Fatal(err)
+	}
+
+	clientFP := c.Fingerprint()
+	server := <-serverFP
+
+	if clientFP != server {
+		t.Fatalf("fingerprint mismatch:\n client: %x\n server: %x", clientFP, server)
+	}
+	var zero [32]byte
+	if clientFP == zero {
+		t.Fatal("fingerprint is zero — handshake didn't complete?")
 	}
 }

--- a/pkg/transport/bolt8/conn.go
+++ b/pkg/transport/bolt8/conn.go
@@ -28,6 +28,10 @@ type Conn struct {
 	sck, rck [32]byte
 	sn, rn   uint64
 
+	// handshakeHash is the final BOLT-8 handshake hash, suitable for
+	// channel binding (returned by Fingerprint).
+	handshakeHash [32]byte
+
 	outLock, inLock sync.Mutex
 	readBuf         []byte
 }
@@ -59,6 +63,20 @@ func (c *Conn) CloseWrite() error {
 	return c.conn.Close()
 }
 
+// Fingerprint returns the BOLT-8 handshake hash after handshake
+// completion. Both peers compute the same 32-byte value; comparing
+// fingerprints out-of-band is the BOLT-8 / Noise way of doing
+// channel binding.
+func (c *Conn) Fingerprint() [32]byte {
+	c.hsMu.Lock()
+	defer c.hsMu.Unlock()
+	if !c.handshakeDone {
+		var zero [32]byte
+		return zero
+	}
+	return c.handshakeHash
+}
+
 // RemoteStatic returns the BOLT-8 remote static public key. For the
 // initiator this is the value supplied at construction. For the
 // responder it is populated after a successful handshake.
@@ -85,21 +103,22 @@ func (c *Conn) Handshake() error {
 		return nil
 	}
 	var (
-		ck  [32]byte
-		err error
+		ck, finalHash [32]byte
+		err           error
 	)
 	if c.isInitiator {
 		if c.remoteStatic == nil {
 			return errors.New("bolt8: initiator missing remote static key")
 		}
-		ck, err = runInitiator(c.conn, c.localStatic, c.remoteStatic, nil)
+		ck, finalHash, err = runInitiator(c.conn, c.localStatic, c.remoteStatic, nil)
 	} else {
 		var rs *secp256k1.PublicKey
-		ck, rs, err = runResponder(c.conn, c.localStatic, nil)
+		ck, finalHash, rs, err = runResponder(c.conn, c.localStatic, nil)
 		if err == nil {
 			c.remoteStatic = rs
 		}
 	}
+	c.handshakeHash = finalHash
 	if err != nil {
 		return err
 	}

--- a/pkg/transport/bolt8/handshake.go
+++ b/pkg/transport/bolt8/handshake.go
@@ -9,20 +9,20 @@ import (
 )
 
 // runInitiator performs acts 1 (write), 2 (read), 3 (write). On success
-// it returns the chaining key after the handshake (the splitKeys input).
+// it returns the chaining key and the final handshake hash.
 func runInitiator(
 	conn io.ReadWriter,
 	localStatic *secp256k1.PrivateKey,
 	remoteStatic *secp256k1.PublicKey,
 	ephemeral *secp256k1.PrivateKey, // injectable for test vectors; nil = generate
-) (ck [32]byte, err error) {
+) (ck, finalHash [32]byte, err error) {
 	remoteStaticPub := remoteStatic.SerializeCompressed()
 	h, ck := initialState(nil, remoteStaticPub, true)
 
 	if ephemeral == nil {
 		ephemeral, err = secp256k1.GeneratePrivateKey()
 		if err != nil {
-			return ck, fmt.Errorf("bolt8: generate ephemeral: %w", err)
+			return ck, finalHash, fmt.Errorf("bolt8: generate ephemeral: %w", err)
 		}
 	}
 	ePub := ephemeral.PubKey().SerializeCompressed()
@@ -33,32 +33,32 @@ func runInitiator(
 	ck, tempK1 := hkdfExpand(ck, es)
 	c, err := encryptWithAD(tempK1, 0, h[:], nil)
 	if err != nil {
-		return ck, err
+		return ck, finalHash, err
 	}
 	mixHash(&h, c)
 	act1 := append([]byte{0x00}, ePub...)
 	act1 = append(act1, c...)
 	if _, err := conn.Write(act1); err != nil {
-		return ck, fmt.Errorf("bolt8: write act 1: %w", err)
+		return ck, finalHash, fmt.Errorf("bolt8: write act 1: %w", err)
 	}
 
 	// Act 2 (responder → initiator): 50 bytes
 	buf := make([]byte, 50)
 	if _, err := io.ReadFull(conn, buf); err != nil {
-		return ck, fmt.Errorf("bolt8: read act 2: %w", err)
+		return ck, finalHash, fmt.Errorf("bolt8: read act 2: %w", err)
 	}
 	if buf[0] != 0x00 {
-		return ck, fmt.Errorf("bolt8: unsupported act 2 version 0x%02x", buf[0])
+		return ck, finalHash, fmt.Errorf("bolt8: unsupported act 2 version 0x%02x", buf[0])
 	}
 	re, err := secp256k1.ParsePubKey(buf[1:34])
 	if err != nil {
-		return ck, fmt.Errorf("bolt8: parse act 2 ephemeral: %w", err)
+		return ck, finalHash, fmt.Errorf("bolt8: parse act 2 ephemeral: %w", err)
 	}
 	mixHash(&h, buf[1:34])
 	ee := ecdh(ephemeral, re)
 	ck, tempK2 := hkdfExpand(ck, ee)
 	if _, err := decryptWithAD(tempK2, 0, h[:], buf[34:50]); err != nil {
-		return ck, fmt.Errorf("bolt8: decrypt act 2: %w", err)
+		return ck, finalHash, fmt.Errorf("bolt8: decrypt act 2: %w", err)
 	}
 	mixHash(&h, buf[34:50])
 
@@ -66,21 +66,22 @@ func runInitiator(
 	localStaticPub := localStaticPub(localStatic)
 	cStatic, err := encryptWithAD(tempK2, 1, h[:], localStaticPub)
 	if err != nil {
-		return ck, err
+		return ck, finalHash, err
 	}
 	mixHash(&h, cStatic)
 	se := ecdh(localStatic, re)
 	ck, tempK3 := hkdfExpand(ck, se)
 	tag, err := encryptWithAD(tempK3, 0, h[:], nil)
 	if err != nil {
-		return ck, err
+		return ck, finalHash, err
 	}
 	act3 := append([]byte{0x00}, cStatic...)
 	act3 = append(act3, tag...)
 	if _, err := conn.Write(act3); err != nil {
-		return ck, fmt.Errorf("bolt8: write act 3: %w", err)
+		return ck, finalHash, fmt.Errorf("bolt8: write act 3: %w", err)
 	}
-	return ck, nil
+	finalHash = h
+	return ck, finalHash, nil
 }
 
 // runResponder performs acts 1 (read), 2 (write), 3 (read). On success
@@ -90,27 +91,27 @@ func runResponder(
 	conn io.ReadWriter,
 	localStatic *secp256k1.PrivateKey,
 	ephemeral *secp256k1.PrivateKey, // injectable for test vectors; nil = generate
-) (ck [32]byte, remoteStatic *secp256k1.PublicKey, err error) {
+) (ck, finalHash [32]byte, remoteStatic *secp256k1.PublicKey, err error) {
 	localStaticPub := localStaticPub(localStatic)
 	h, ck := initialState(localStaticPub, nil, false)
 
 	// Act 1 (initiator → responder)
 	buf := make([]byte, 50)
 	if _, err := io.ReadFull(conn, buf); err != nil {
-		return ck, nil, fmt.Errorf("bolt8: read act 1: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: read act 1: %w", err)
 	}
 	if buf[0] != 0x00 {
-		return ck, nil, fmt.Errorf("bolt8: unsupported act 1 version 0x%02x", buf[0])
+		return ck, finalHash, nil, fmt.Errorf("bolt8: unsupported act 1 version 0x%02x", buf[0])
 	}
 	re, err := secp256k1.ParsePubKey(buf[1:34])
 	if err != nil {
-		return ck, nil, fmt.Errorf("bolt8: parse act 1 ephemeral: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: parse act 1 ephemeral: %w", err)
 	}
 	mixHash(&h, buf[1:34])
 	es := ecdh(localStatic, re)
 	ck, tempK1 := hkdfExpand(ck, es)
 	if _, err := decryptWithAD(tempK1, 0, h[:], buf[34:50]); err != nil {
-		return ck, nil, fmt.Errorf("bolt8: decrypt act 1: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: decrypt act 1: %w", err)
 	}
 	mixHash(&h, buf[34:50])
 
@@ -118,7 +119,7 @@ func runResponder(
 	if ephemeral == nil {
 		ephemeral, err = secp256k1.GeneratePrivateKey()
 		if err != nil {
-			return ck, nil, fmt.Errorf("bolt8: generate ephemeral: %w", err)
+			return ck, finalHash, nil, fmt.Errorf("bolt8: generate ephemeral: %w", err)
 		}
 	}
 	ePub := ephemeral.PubKey().SerializeCompressed()
@@ -127,41 +128,42 @@ func runResponder(
 	ck, tempK2 := hkdfExpand(ck, ee)
 	c, err := encryptWithAD(tempK2, 0, h[:], nil)
 	if err != nil {
-		return ck, nil, err
+		return ck, finalHash, nil, err
 	}
 	mixHash(&h, c)
 	act2 := append([]byte{0x00}, ePub...)
 	act2 = append(act2, c...)
 	if _, err := conn.Write(act2); err != nil {
-		return ck, nil, fmt.Errorf("bolt8: write act 2: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: write act 2: %w", err)
 	}
 
 	// Act 3 (initiator → responder): 66 bytes
 	buf3 := make([]byte, 66)
 	if _, err := io.ReadFull(conn, buf3); err != nil {
-		return ck, nil, fmt.Errorf("bolt8: read act 3: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: read act 3: %w", err)
 	}
 	if buf3[0] != 0x00 {
-		return ck, nil, fmt.Errorf("bolt8: unsupported act 3 version 0x%02x", buf3[0])
+		return ck, finalHash, nil, fmt.Errorf("bolt8: unsupported act 3 version 0x%02x", buf3[0])
 	}
 	rsBytes, err := decryptWithAD(tempK2, 1, h[:], buf3[1:50])
 	if err != nil {
-		return ck, nil, fmt.Errorf("bolt8: decrypt act 3 static: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: decrypt act 3 static: %w", err)
 	}
 	if len(rsBytes) != 33 {
-		return ck, nil, errors.New("bolt8: act 3 static key wrong length")
+		return ck, finalHash, nil, errors.New("bolt8: act 3 static key wrong length")
 	}
 	remoteStatic, err = secp256k1.ParsePubKey(rsBytes)
 	if err != nil {
-		return ck, nil, fmt.Errorf("bolt8: parse act 3 static: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: parse act 3 static: %w", err)
 	}
 	mixHash(&h, buf3[1:50])
 	se := ecdh(ephemeral, remoteStatic)
 	ck, tempK3 := hkdfExpand(ck, se)
 	if _, err := decryptWithAD(tempK3, 0, h[:], buf3[50:66]); err != nil {
-		return ck, nil, fmt.Errorf("bolt8: decrypt act 3 tag: %w", err)
+		return ck, finalHash, nil, fmt.Errorf("bolt8: decrypt act 3 tag: %w", err)
 	}
-	return ck, remoteStatic, nil
+	finalHash = h
+	return ck, finalHash, remoteStatic, nil
 }
 
 // localStaticPub returns the SEC1-compressed 33-byte serialization of the

--- a/pkg/transport/noisesocket/conn.go
+++ b/pkg/transport/noisesocket/conn.go
@@ -83,6 +83,21 @@ func (c *Conn) CloseWrite() error {
 	return c.conn.Close()
 }
 
+// Fingerprint returns the Noise handshake hash after handshake
+// completion. See the raw transport's docs for usage; both peers
+// compute the same value and it is suitable for channel binding.
+func (c *Conn) Fingerprint() [32]byte {
+	c.handshakeMu.Lock()
+	defer c.handshakeMu.Unlock()
+	var out [32]byte
+	if !c.handshakeDone || c.hs == nil {
+		return out
+	}
+	h := c.hs.ChannelBinding()
+	copy(out[:], h)
+	return out
+}
+
 // Server wraps an existing net.Conn into a NoiseSocket server-side conn.
 // initialNegData and appPrologue are mixed into the handshake hash via
 // the spec's prologue formula.
@@ -199,6 +214,9 @@ func (c *Conn) Write(p []byte) (int, error) {
 
 		ciphertext, err := c.out.Encrypt(nil, nil, plaintext)
 		if err != nil {
+			if errors.Is(err, noise.ErrMaxNonce) {
+				_ = c.conn.Close()
+			}
 			return total, fmt.Errorf("noisesocket: Encrypt: %w", err)
 		}
 		if err := writeLengthPrefixed(c.conn, ciphertext); err != nil {
@@ -235,6 +253,9 @@ func (c *Conn) Read(p []byte) (int, error) {
 	}
 	plaintext, err := c.in.Decrypt(nil, nil, ciphertext)
 	if err != nil {
+		if errors.Is(err, noise.ErrMaxNonce) {
+			_ = c.conn.Close()
+		}
 		return 0, fmt.Errorf("noisesocket: Decrypt: %w", err)
 	}
 	if len(plaintext) < 2 {

--- a/pkg/transport/raw/conn.go
+++ b/pkg/transport/raw/conn.go
@@ -95,6 +95,13 @@ func (c *Conn) Write(b []byte) (int, error) {
 		// Encrypt
 		ciphertext, err := c.out.Encrypt(nil, nil, data[:m])
 		if err != nil {
+			// Per the Noise spec §5.3, on nonce exhaustion the session
+			// must be terminated. Surface the error and close the conn
+			// so subsequent reads/writes return cleanly instead of
+			// trying to reuse a poisoned CipherState.
+			if errors.Is(err, noise.ErrMaxNonce) {
+				_ = c.conn.Close()
+			}
 			return n, err
 		}
 
@@ -176,6 +183,10 @@ func (c *Conn) Read(b []byte) (int, error) {
 	// decrypt
 	plaintext, err := c.in.Decrypt(nil, nil, noiseMessage)
 	if err != nil {
+		// Noise spec §5.3: terminate the session on nonce exhaustion.
+		if errors.Is(err, noise.ErrMaxNonce) {
+			_ = c.conn.Close()
+		}
 		return 0, err
 	}
 
@@ -214,6 +225,24 @@ func (c *Conn) CloseWrite() error {
 		return cw.CloseWrite()
 	}
 	return c.conn.Close()
+}
+
+// Fingerprint returns the Noise handshake hash, suitable for channel
+// binding (Noise spec §11.2). The hash is only available after the
+// handshake has completed; calling it earlier returns the zero value.
+// Both peers compute the same hash; comparing them lets higher-level
+// protocols detect MITM that would otherwise validate against the
+// underlying key material but still produce diverging session state.
+func (c *Conn) Fingerprint() [32]byte {
+	c.handshakeMutex.Lock()
+	defer c.handshakeMutex.Unlock()
+	var out [32]byte
+	if !c.handshakeComplete || c.hs == nil {
+		return out
+	}
+	h := c.hs.ChannelBinding()
+	copy(out[:], h)
+	return out
 }
 
 // Noise-related functions


### PR DESCRIPTION
Stacked on #12. Two small Noise-spec conformance polish items.

## 1. Close on \`ErrMaxNonce\`

Noise spec §5.3:
> the application must delete the \`CipherState\` and terminate the session

\`pkg/transport/raw\` and \`pkg/transport/noisesocket\` now \`Close()\` the underlying conn on \`noise.ErrMaxNonce\` in addition to surfacing the error. \`pkg/transport/bolt8\` rekeys every 1000 messages and never gets near \`2^64-1\`, so no change there.

## 2. \`Fingerprint()\` for channel binding

Every transport's \`Conn\` now exposes \`Fingerprint() [32]byte\` returning the final handshake hash. Both peers compute the same 32 bytes; comparing them out-of-band lets higher-level protocols detect active MITM that would otherwise validate but diverge.

- \`pkg/transport/raw\` / \`pkg/transport/noisesocket\` use flynn/noise's \`HandshakeState.ChannelBinding()\`.
- \`pkg/transport/bolt8\` stores its own final SHA-256 chain after act 3.

\`TestFingerprintMatches\` pairs an initiator and responder over loopback and asserts identical fingerprints.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race -timeout 60s ./...\`
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)