### PR TITLE
fix: validate.go uses post-#15 parseProtocolName signature

### DIFF
--- a/pkg/noisecat/validate.go
+++ b/pkg/noisecat/validate.go
@@ -49,7 +49,7 @@ func ValidateStaticKey(b64 string, dhFunc byte) error {
 // Noise protocol name to determine the DH function before validating.
 // Useful for CLI tools that already have a -proto string in hand.
 func ValidateStaticKeyForProtocol(b64, protoName string) error {
-	_, dhFunc, _, _, err := parseProtocolName(protoName)
+	_, dhFunc, _, _, _, err := parseProtocolName(protoName)
 	if err != nil {
 		return fmt.Errorf("can't determine DH function from protocol %q: %w", protoName, err)
 	}


### PR DESCRIPTION
Master is broken since #14 and #15 were merged in parallel. The semantic conflict slipped past textual conflict detection.

\`pkg/noisecat/validate.go:52\` calls \`parseProtocolName\` expecting 5 return values (its signature before #15). #15 added a sixth — the \`psk int8\` placement. One-line fix.

\`\`\`go
- _, dhFunc, _, _, err := parseProtocolName(protoName)
+ _, dhFunc, _, _, _, err := parseProtocolName(protoName)
\`\`\`

## Test plan

- [x] \`go build ./...\` — passes
- [x] \`go vet ./...\` — passes
- [x] \`go test -race -timeout 60s ./...\` — passes
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)