### PR TITLE
fix: reject transport/DH mismatches + safe PSKPlacement default (stacked on #18)

### DIFF
--- a/cmd/noisecat/main.go
+++ b/cmd/noisecat/main.go
@@ -11,7 +11,11 @@ import (
 var version = "1.0"
 
 func parseFlags() noisecat.Config {
-	config := noisecat.Config{}
+	// PSKPlacement's zero value (0) is a valid PSK placement index per
+	// the Noise spec; initialize the field to the NoPSK sentinel so a
+	// Config that never goes through parseProtocolName cannot
+	// accidentally install a PSK at placement 0.
+	config := noisecat.Config{PSKPlacement: noisecat.NoPSK}
 
 	flag.Usage = usage
 	flag.StringVar(&config.ExecuteCmd, "e", "", "executes the given `command`")

--- a/pkg/noisecat/net.go
+++ b/pkg/noisecat/net.go
@@ -24,8 +24,16 @@ type Noisecat struct {
 }
 
 // resolveTransport selects a Transport implementation based on the
-// noisecat Config. An empty / "raw" Transport field defaults to the
-// historical framing.
+// noisecat Config and validates that the chosen transport is
+// compatible with the Noise protocol's DH function. An empty / "raw"
+// Transport field defaults to the historical framing.
+//
+// Compatibility rules:
+//   - bolt8 only speaks Noise_XK_secp256k1_ChaChaPoly_SHA256, so it
+//     requires DHFunc == NOISE_DH_SECP256K1.
+//   - raw and noisesocket sit on top of flynn/noise's DH primitives
+//     and therefore cannot accept secp256k1 (which BOLT-8 implements
+//     directly, outside flynn/noise).
 func resolveTransport(cfg *Config) (transport.Transport, error) {
 	name := cfg.Transport
 	if name == "" {
@@ -33,10 +41,19 @@ func resolveTransport(cfg *Config) (transport.Transport, error) {
 	}
 	switch name {
 	case "raw":
+		if cfg.DHFunc == NOISE_DH_SECP256K1 {
+			return nil, fmt.Errorf("transport=raw cannot speak secp256k1; use -transport bolt8")
+		}
 		return raw.New(), nil
 	case "noisesocket":
+		if cfg.DHFunc == NOISE_DH_SECP256K1 {
+			return nil, fmt.Errorf("transport=noisesocket cannot speak secp256k1; use -transport bolt8")
+		}
 		return noisesocket.New(), nil
 	case "bolt8":
+		if cfg.DHFunc != NOISE_DH_SECP256K1 {
+			return nil, fmt.Errorf("transport=bolt8 only supports secp256k1; the chosen DH function is not")
+		}
 		return bolt8.New(), nil
 	default:
 		return nil, fmt.Errorf("unknown transport %q (expected: raw, noisesocket, bolt8)", name)

--- a/pkg/noisecat/transport_validation_test.go
+++ b/pkg/noisecat/transport_validation_test.go
@@ -1,0 +1,88 @@
+package noisecat
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveTransportRejectsMismatchedDH ensures the CLI surfaces a
+// clear error when the user combines a transport with an incompatible
+// DH function. Three combinations are illegal:
+//
+//   - transport=bolt8 with a Curve25519 protocol (bolt8 only speaks
+//     secp256k1).
+//   - transport=raw with a secp256k1 protocol (raw uses flynn/noise,
+//     which has no secp256k1 DH function).
+//   - transport=noisesocket with a secp256k1 protocol (same reason).
+func TestResolveTransportRejectsMismatchedDH(t *testing.T) {
+	cases := []struct {
+		name      string
+		transport string
+		dhFunc    byte
+		wantErr   string
+	}{
+		{
+			name:      "bolt8 + curve25519",
+			transport: "bolt8",
+			dhFunc:    NOISE_DH_CURVE25519,
+			wantErr:   "bolt8 only supports secp256k1",
+		},
+		{
+			name:      "raw + secp256k1",
+			transport: "raw",
+			dhFunc:    NOISE_DH_SECP256K1,
+			wantErr:   "raw cannot speak secp256k1",
+		},
+		{
+			name:      "noisesocket + secp256k1",
+			transport: "noisesocket",
+			dhFunc:    NOISE_DH_SECP256K1,
+			wantErr:   "noisesocket cannot speak secp256k1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Transport: tc.transport, DHFunc: tc.dhFunc}
+			_, err := resolveTransport(cfg)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestResolveTransportAcceptsValidCombos covers the happy path: each
+// transport accepts at least one DH function.
+func TestResolveTransportAcceptsValidCombos(t *testing.T) {
+	cases := []struct {
+		transport string
+		dhFunc    byte
+	}{
+		{transport: "", dhFunc: NOISE_DH_CURVE25519},            // default → raw
+		{transport: "raw", dhFunc: NOISE_DH_CURVE25519},
+		{transport: "noisesocket", dhFunc: NOISE_DH_CURVE25519},
+		{transport: "bolt8", dhFunc: NOISE_DH_SECP256K1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.transport+"+"+strconvDH(tc.dhFunc), func(t *testing.T) {
+			cfg := &Config{Transport: tc.transport, DHFunc: tc.dhFunc}
+			if _, err := resolveTransport(cfg); err != nil {
+				t.Fatalf("unexpected error for %s + %d: %v", tc.transport, tc.dhFunc, err)
+			}
+		})
+	}
+}
+
+func strconvDH(b byte) string {
+	switch b {
+	case NOISE_DH_CURVE25519:
+		return "25519"
+	case NOISE_DH_SECP256K1:
+		return "secp256k1"
+	default:
+		return "?"
+	}
+}

--- a/pkg/noisecat/utils.go
+++ b/pkg/noisecat/utils.go
@@ -45,11 +45,17 @@ func GenerateKeypair(dh, cipher, hash byte) ([]byte, error) {
 	return json.Marshal(keypair)
 }
 
-// noPSK is the sentinel value returned by parseProtocolName for protocols
-// without a psk modifier. -1 fits the int8 type used in noise.Config's
-// PresharedKeyPlacement (where 0 is a valid placement index, so a separate
-// "unset" value is needed).
-const noPSK int8 = -1
+// NoPSK is the sentinel value returned by parseProtocolName for
+// protocols without a psk modifier. -1 fits the int8 type used in
+// noise.Config's PresharedKeyPlacement (where 0 is a valid placement
+// index, so a separate "unset" value is needed). External callers
+// constructing a Config{} from scratch should initialize
+// Config.PSKPlacement to NoPSK — otherwise the zero value would
+// look like a request for psk0 placement.
+const NoPSK int8 = -1
+
+// noPSK is the legacy in-package alias for NoPSK kept for diff-stability.
+const noPSK = NoPSK
 
 // protocolRegexp matches Noise protocol names like
 //


### PR DESCRIPTION
Stacked on #18. Closes review findings H2 and H3.

## H2 — transport/DH compatibility validated at config time

\`resolveTransport\` in \`pkg/noisecat/net.go\` now rejects three illegal combinations before any socket is opened:

| Transport | DH function | Result |
|---|---|---|
| \`bolt8\` | Curve25519 | error: \"transport=bolt8 only supports secp256k1\" |
| \`raw\` | secp256k1 | error: \"transport=raw cannot speak secp256k1; use -transport bolt8\" |
| \`noisesocket\` | secp256k1 | error: \"transport=noisesocket cannot speak secp256k1; use -transport bolt8\" |

The auto-promotion of \`secp256k1 → bolt8\` that happens in \`parseNoise\` is unchanged, so the common case (\"user picks secp256k1 protocol, leaves -transport default\") still works.

## H3 — safe PSKPlacement default

\`Config.PSKPlacement\`'s zero value is 0, which is a valid \`psk0\` placement index. The new exported sentinel \`NoPSK\` (\`= -1\`) is what \`parseProtocolName\` returns when the protocol name has no \`psk\` modifier. \`cmd/noisecat/main.go\`'s \`parseFlags\` now initializes \`Config{PSKPlacement: noisecat.NoPSK}\` so a fresh CLI invocation can't slide into psk0 placement through the zero-value path.

The doc-comment on \`NoPSK\` calls out the invariant for external library users who build a \`Config\` by hand.

## Tests

- \`TestResolveTransportRejectsMismatchedDH\` parametrized over the three illegal combinations.
- \`TestResolveTransportAcceptsValidCombos\` parametrized over the four supported pairings (\`raw+25519\`, \`noisesocket+25519\`, \`bolt8+secp256k1\`, and the empty-transport default).

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race -timeout 120s ./...\`
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)